### PR TITLE
Fix comment for missing variables in PCA BC

### DIFF
--- a/PCA BC.py
+++ b/PCA BC.py
@@ -541,9 +541,9 @@ vars=[norm_adj_sentiment, norm_adj_sticky, norm_adj_vix, norm_adj_policy, norm_a
     norm_adj_trans_receipt, nomr_adj_vehicle_loans, norm_adj_bank_credit, norm_adj_personal_savings]
 
 '''Variables to add:
-    Baker Highes US Rig Count
+    Baker Hughes US Rig Count
     NFIB Small Business Index
-    '''
+'''
 
 for n in vars:
     df=df.join(n,how='outer') 


### PR DESCRIPTION
## Summary
- fix the spelling of "Baker Hughes" in the comment
- adjust the multiline comment formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab213cfd88332967f476fc103554e