### PR TITLE
Add setup script for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# PCA Business Cycle
+
+This repository contains a Python script `PCA BC.py` that generates a business cycle report and related visualizations. The script relies on several external libraries such as pandas, matplotlib and scikit-learn.
+
+## Setup
+
+Run the provided `setup.sh` script to install the required dependencies. The script uses `apt-get` and `pip` to install Python and all Python packages listed in `requirements.txt`.
+
+```bash
+./setup.sh
+```
+
+Network access is required for the installation as well as for the script itself, which downloads economic data and market prices.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+pandas
+pandas_datareader
+reportlab
+matplotlib
+numpy
+scipy
+scikit-learn
+yfinance

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Setup script for PCA_Business_Cycle project
+set -e
+
+# Ensure apt repositories are updated
+sudo apt-get update
+
+# Install python and pip if not already available
+sudo apt-get install -y python3 python3-pip
+
+# Upgrade pip
+python3 -m pip install --upgrade pip
+
+# Install Python dependencies
+python3 -m pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- add a `setup.sh` to install packages
- list required packages in `requirements.txt`
- document setup instructions in `README`

## Testing
- `pip install -r requirements.txt`
- `python3 -m py_compile 'PCA BC.py'`

------
https://chatgpt.com/codex/tasks/task_e_686ad76c16f483329ad4079958abe1ee